### PR TITLE
Fixed issues in AllAdminTest test suite

### DIFF
--- a/PortalMeetupTests/Portal/PortalFramework/src/AdminFeatures/CommunityFormCheck.java
+++ b/PortalMeetupTests/Portal/PortalFramework/src/AdminFeatures/CommunityFormCheck.java
@@ -16,8 +16,8 @@ public class CommunityFormCheck
 	 */
 	public static boolean IsForm() 
 	{
-		       //Store the current window handle
-				//String oldURL = Driver.Instance.getWindowHandle();
+		        //Store the current window handle
+				String oldURL = Driver.Instance.getWindowHandle();
 				
 				//Click operation
 				Driver.Instance.findElement(PageObjRef.CommunityTab).click();
@@ -35,10 +35,10 @@ public class CommunityFormCheck
 			    String check=FormTitle.getText();
 			    
 			    //Close the new window
-			   // Driver.Instance.close();
+			      Driver.Instance.close();
 
 			    //Switch back to original window
-		        //Driver.Instance.switchTo().window(oldURL);
+		          Driver.Instance.switchTo().window(oldURL);
 		        
 		        if(check.equals("Anita Borg Institute Community Proposal Form"))
 		        	return true;

--- a/PortalMeetupTests/Portal/PortalFramework/src/AdminFeatures/EditPage.java
+++ b/PortalMeetupTests/Portal/PortalFramework/src/AdminFeatures/EditPage.java
@@ -24,6 +24,11 @@ public class EditPage
 		return new UpdateCommand(change);
 	}
 	
+	public static UpdateCommand ChangeFirstNameTo(String change){
+		
+		return new UpdateCommand(change);
+	}
+	
 	public static UpdateCommand ChangeBlogTo(String change)
 	{
 		

--- a/PortalMeetupTests/Portal/PortalFramework/src/AdminFeatures/UpdateCommand.java
+++ b/PortalMeetupTests/Portal/PortalFramework/src/AdminFeatures/UpdateCommand.java
@@ -62,4 +62,13 @@ public class UpdateCommand
 		Submit.click();
 	}
 
+	public void SetFirstName()
+	{
+		//Find first name
+		WebElement firstName = Driver.Instance.findElement(PageObjRef.Firstname);
+		firstName.clear();
+		
+		//Enter a new first name
+		firstName.sendKeys(change);
+	}
 }

--- a/PortalMeetupTests/Portal/PortalFramework/src/AdminFeatures/ViewUpdate.java
+++ b/PortalMeetupTests/Portal/PortalFramework/src/AdminFeatures/ViewUpdate.java
@@ -10,14 +10,14 @@ import WebDriver.Driver;
 public class ViewUpdate 
 {
 
-	public static boolean HasChangedto(String newLastName)
+	public static boolean HasChangedto(String fullName)
 	{
 		 //Checks for updated name and validates update
 		 WebElement UpdatedName=Driver.Instance.findElement(PageObjRef.UpdatedName);
 		 String check=UpdatedName.getText();//getText() extracts string in upper case 
 	     
 		 //Validate
-		  if((check).contains(newLastName.toUpperCase()))
+		  if((check).contains(fullName.toUpperCase()))
 			  return true;
 		  else
 			  return false;

--- a/PortalMeetupTests/Portal/PortalFramework/src/PageElements/PageObjRef.java
+++ b/PortalMeetupTests/Portal/PortalFramework/src/PageElements/PageObjRef.java
@@ -12,7 +12,7 @@ public class PageObjRef
 
 	//HomePage Elements
 	public static By CommunityTab = By.xpath("html/body/div[1]/div/div[2]/ul[1]/li[2]/a");
-	public static By ChooseCommunity = By.xpath("html/body/div[1]/div/div[2]/ul[1]/li[2]/ul/li[3]/a");
+	public static By ChooseCommunity = By.xpath("//ul[@class='dropdown-menu']/li[2]/a");
     public static By ReadMore1 = By.xpath("html/body/div[2]/div[2]/div[1]/a");
     public static By ReadMore2 = By.xpath("html/body/div[2]/div[4]/div[1]/a");
     public static By ReadMore3 = By.xpath("html/body/div[2]/div[3]/div[2]/a");
@@ -62,6 +62,7 @@ public class PageObjRef
     
     //User/Admin Profile Page
     public static By Edit= By.xpath("html/body/div[3]/div[2]/div[2]/div/div[2]/div[1]/a");
+    public static By Firstname= By.id("id_first_name");
     public static By Lastname= By.id("id_last_name");
     public static By Submit= By.id("submit-id-save");
     public static By Blog= By.id("id_blog_url");

--- a/PortalMeetupTests/Portal/PortalTests/src/AdminTests/CanChangePasswordTest.java
+++ b/PortalMeetupTests/Portal/PortalTests/src/AdminTests/CanChangePasswordTest.java
@@ -13,7 +13,7 @@ import BaseTests.CommonTests;
  */
 public class CanChangePasswordTest extends CommonTests
 {
-    private String OldPassword="anjali", NewPassword="anjali";
+    private String OldPassword="dummyPassword", NewPassword="dummyPassword";
 	@Test
 	public void test() 
 	{

--- a/PortalMeetupTests/Portal/PortalTests/src/AdminTests/CanEditTest.java
+++ b/PortalMeetupTests/Portal/PortalTests/src/AdminTests/CanEditTest.java
@@ -13,12 +13,13 @@ import BaseTests.CommonTests;
 public class CanEditTest extends CommonTests
 {
 	/*
-	 * Tests if an admin can update her last name after logging  in, clicking on edit,
-	 *  entering new last name and then view changes
+	 * Tests if an admin can update his/her first and last name after logging  in, 
+	 * clicking on edit, entering new last name and then view changes
 	 */
 	@Test
 	public void test()
 	{
+		String newFirstName="Henry";
 		String newLastName="Shally";
 		//Log in
 		AdminLogin.login();
@@ -26,11 +27,14 @@ public class CanEditTest extends CommonTests
 		//Navigate to edit Profile
 		EditPage.Goto();
 		
+		//Enter new first name
+		EditPage.ChangeFirstNameTo(newFirstName).SetFirstName();;
+		
 		//Enter new last name and click update
 		EditPage.ChangeLastnameTo(newLastName).Update();
 		
 		//Validate
-		Assert.assertEquals(true,ViewUpdate.HasChangedto(newLastName));	
+		Assert.assertEquals(true,ViewUpdate.HasChangedto(newFirstName + " " + newLastName));	
 	}
 
 }


### PR DESCRIPTION
CanEditTest will now test both first and last name. If only one of the two are tested, the webpage does not update with the new name, so the test will automatically fail.

CanChangePassword now uses the default password for logging in (for consistency).

Fixed invalid xpath for community button

All tests in AllAdminTest suite will successfully pass.

